### PR TITLE
Initial commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ crash.log
 crash.*.log
 
 # Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,68 @@
 # terraform-thoras-eks-efs
-Terraform module for provisioning an EFS volume for EKS running Thoras
+
+## When to use this module
+
+Use this Terraform module as a pre-step to installing Thoras when:
+
+1) You're installing Thoras in an EKS cluster
+1) ...and you're using [EFS for EKS](https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html) as Thoras' storage backend (recommended)
+1) ...and the EFS EKS AddOn is not set up in your cluster
+1) ...and you'd like to automate the EFS EKS AddOn setup along with everything it needs (cluster OIDC IAM provider, security group, IAM role)
+
+## Usage
+
+```hcl
+module "thoras_efs" {
+  source                     = "thoras/thoras"
+  version                    = "3.1.1"
+  cluster_name               = "my-cluster"
+  region                     = "us-east-1"
+  cluster_node_group_subnets = [
+    "subnet-aaaa",
+    "subnet-bbbb",
+    "subnet-cccc"
+  ]
+}
+```
+
+## Resources created / managed by module
+
+| Resource | Description |
+|----------|-------------|
+| **Thoras EFS filesystem** | the AWS EFS fs that will store Thoras historical data |
+| **An EFS backup policy** | Provides a way to restore data if needed |
+| **[EFS AddOn for EKS](https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html)** | The required EKS add-on for enabling EFS mount points in an EKS cluster |
+| **IAM OIDC Provider for EKS cluster** | Allows EKS service accounts to use IAM roles |
+| **Cluster EFS driver IAM role** | Allows EFS driver for EKS to access EFS filesystem |
+| **Security Group for Thoras EFS Filesystem** | Security Group with an inbound rule that allows port 2049 tcp from node group subnets |
+
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| `region` | AWS region hosting target EKS and EFS resources | `string` | `null` | yes |
+| `cluster_name` | name of EKS cluster accessing EFS volume        | `string` | `null` | yes |
+| `cluster_node_group_subnets` | EKS node group subnets that will access EFS | `list(string)` | `null` | yes |
+| `efs_addon_version` | version of EFS addon for EKS | `string` | `v1.7.7-eksbuild.1` | yes |
+| `efs_tags` | resource tags for Thoras EFS volume | `map(string)` | `{}` | no |
+| `security_group_tags` | resource tags for Thoras EFS security group | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description | Type |
+|------|-------------|------|
+| `fs_id` | ID of Thoras EFS volume | `string` |
+| `volume_name` | name of Thoras EFS volume | `string` |

--- a/bin/get_thumbprint.sh
+++ b/bin/get_thumbprint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Thank you https://github.com/hashicorp/terraform-provider-aws/issues/10104#issuecomment-534937559
+THUMBPRINT=$(echo | openssl s_client -servername oidc.eks.${1}.amazonaws.com -showcerts -connect oidc.eks.${1}.amazonaws.com:443 2>&- | tac | sed -n '/-----END CERTIFICATE-----/,/-----BEGIN CERTIFICATE-----/p; /-----BEGIN CERTIFICATE-----/q' | tac | openssl x509 -fingerprint -noout | sed 's/://g' | awk -F= '{print tolower($2)}')
+THUMBPRINT_JSON="{\"thumbprint\": \"${THUMBPRINT}\"}"
+echo $THUMBPRINT_JSON

--- a/efs.tf
+++ b/efs.tf
@@ -1,0 +1,23 @@
+resource "aws_efs_file_system" "data" {
+  creation_token = local.efs_tags.Name
+  encrypted      = true
+  tags           = local.efs_tags
+}
+
+resource "aws_efs_mount_target" "data" {
+  for_each = toset(var.cluster_node_group_subnets)
+
+  file_system_id = aws_efs_file_system.data.id
+  subnet_id      = each.value
+  security_groups = [
+    aws_security_group.efs.id
+  ]
+}
+
+resource "aws_efs_backup_policy" "data" {
+  file_system_id = aws_efs_file_system.data.id
+
+  backup_policy {
+    status = "ENABLED"
+  }
+}

--- a/eks.tf
+++ b/eks.tf
@@ -1,0 +1,19 @@
+data "aws_eks_cluster" "target" {
+  name = var.cluster_name
+}
+
+data "aws_subnet" "nodes_for_efs_access" {
+  for_each = toset(var.cluster_node_group_subnets)
+  id       = each.value
+}
+
+resource "aws_eks_addon" "efs" {
+  count = var.install_efs_eks_addon ? 1 : 0
+
+  cluster_name                = var.cluster_name
+  addon_name                  = "aws-efs-csi-driver"
+  addon_version               = var.efs_addon_version
+  resolve_conflicts_on_update = "PRESERVE"
+
+  service_account_role_arn = aws_iam_role.cluster_efs_driver.arn
+}

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,42 @@
+# AWS Managed IAM Policy for EFS Driver
+data "aws_iam_policy" "efs_driver" {
+  arn = "arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy"
+}
+
+resource "aws_iam_role" "cluster_efs_driver" {
+  name = "thoras-efs-${var.cluster_name}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Effect = "Allow"
+        Principal = {
+          Federated = "arn:aws:iam::${local.account_id}:oidc-provider/${local.cluster_oidc_url_stripped}"
+        }
+        Condition = {
+          StringLike = {
+            "${local.cluster_oidc_url_stripped}:aud" : "sts.amazonaws.com"
+            "${local.cluster_oidc_url_stripped}:sub" : "system:serviceaccount:kube-system:efs-csi-*"
+          }
+        }
+      },
+    ]
+  })
+
+  managed_policy_arns = [data.aws_iam_policy.efs_driver.arn]
+}
+
+data "external" "thumbprint" {
+  program = [
+    format("%s/bin/get_thumbprint.sh", path.module),
+    var.region
+  ]
+}
+
+resource "aws_iam_openid_connect_provider" "cluster" {
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.external.thumbprint.result.thumbprint]
+  url             = data.aws_eks_cluster.target.identity.0.oidc.0.issuer
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,21 @@
+locals {
+  efs_tags = merge(
+    { Name = "thoras-data-${var.cluster_name}" },
+    var.efs_tags
+  )
+
+  security_group_tags = merge(
+    { Name = "thoras-efs-${var.cluster_name}" },
+    var.security_group_tags
+  )
+
+  cluster_oidc_url_stripped = trimprefix(
+    data.aws_eks_cluster.target.identity.0.oidc.0.issuer,
+    "https://"
+  )
+
+  # We can extract the account ID out of any of the subnets
+  account_id = data.aws_subnet.nodes_for_efs_access[
+    var.cluster_node_group_subnets[0]
+  ].owner_id
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,7 @@
+output "fs_id" {
+  value = aws_efs_file_system.data.id
+}
+
+output "volume_name" {
+  value = aws_efs_file_system.data.name
+}

--- a/security_group.tf
+++ b/security_group.tf
@@ -1,0 +1,22 @@
+resource "aws_security_group" "efs" {
+  name        = "thoras-efs-${var.cluster_name}"
+  description = "allow EKS nodes to ingress to EFS volume"
+
+  # vpc_config is technically a list but in practice
+  # contains only one element
+  vpc_id = data.aws_eks_cluster.target.vpc_config.0.vpc_id
+  tags   = local.security_group_tags
+}
+
+resource "aws_vpc_security_group_ingress_rule" "efs_access_from_cluster" {
+  for_each = toset([
+    for subnet in data.aws_subnet.nodes_for_efs_access : subnet.cidr_block
+  ])
+
+  security_group_id = aws_security_group.efs.id
+
+  cidr_ipv4   = each.value
+  ip_protocol = "tcp"
+  from_port   = 2049
+  to_port     = 2049
+}

--- a/vars.tf
+++ b/vars.tf
@@ -1,0 +1,41 @@
+variable "region" {
+  type        = string
+  description = "AWS region hosting target EKS and EFS resources"
+  nullable    = false
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "name of EKS cluster accessing EFS volume"
+  nullable    = false
+}
+
+variable "cluster_node_group_subnets" {
+  type        = list(string)
+  description = "EKS node group subnets that will access EFS"
+  nullable    = false
+}
+
+variable "efs_addon_version" {
+  type        = string
+  description = "version of EFS addon for EKS"
+  default     = "v1.7.7-eksbuild.1"
+}
+
+variable "install_efs_eks_addon" {
+  type        = bool
+  description = "Whether to install the EKS addon for EFS"
+  default     = true
+}
+
+variable "efs_tags" {
+  type        = map(string)
+  description = "resource tags for EFS volume"
+  default     = {}
+}
+
+variable "security_group_tags" {
+  type        = map(string)
+  description = "resource tags for EFS security group"
+  default     = {}
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
# Why?

We highly recommend EKS customers use [EFS for EKS](https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html) as the Thoras storage backend.

The problem is there's quite a bit of persnickity config required to enable it

So we automate it!

# What's changing?

This is the initial module code and documentation