### PR TITLE
Use DI for module instead of data resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,16 @@ Use this Terraform module as a pre-step to installing Thoras when:
 
 ```hcl
 module "thoras_efs" {
-  source                     = "github.com/thoras-ai/terraform-thoras-eks-efs?ref=1.0.0
-  cluster_name               = "my-cluster"
-  region                     = "us-east-1"
-  cluster_node_group_subnets = [
-    "subnet-aaaa",
-    "subnet-bbbb",
-    "subnet-cccc"
-  ]
+    source                     = "github.com/thoras-ai/terraform-thoras-eks-efs?ref=1.0.0
+    vpc_id                     = "<my vpc_ id>"
+    identity_oidc_issuer       = "https://<my cluster oidc issuer url>"
+    cluster_name               = "my-cluster"
+    region                     = "us-east-1"
+    cluster_node_group_subnets = [
+        "subnet-aaaa",
+        "subnet-bbbb",
+        "subnet-cccc"
+    ]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ module "thoras_efs" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | `region` | AWS region hosting target EKS and EFS resources | `string` | `null` | yes |
+| `vpc_id` | AWS VPC hosting target EKS and EFS resources | `string` | `null` | yes |
+| `identity_oidc_issuer` | OIDC issuer URL for the EKS cluster | `string` | `null` | yes |
 | `cluster_name` | name of EKS cluster accessing EFS volume        | `string` | `null` | yes |
 | `cluster_node_group_subnets` | EKS node group subnets that will access EFS | `list(string)` | `null` | yes |
 | `efs_addon_version` | version of EFS addon for EKS | `string` | `v1.7.7-eksbuild.1` | yes |

--- a/eks.tf
+++ b/eks.tf
@@ -1,7 +1,3 @@
-data "aws_eks_cluster" "target" {
-  name = var.cluster_name
-}
-
 data "aws_subnet" "nodes_for_efs_access" {
   for_each = toset(var.cluster_node_group_subnets)
   id       = each.value

--- a/iam.tf
+++ b/iam.tf
@@ -38,5 +38,5 @@ data "external" "thumbprint" {
 resource "aws_iam_openid_connect_provider" "cluster" {
   client_id_list  = ["sts.amazonaws.com"]
   thumbprint_list = [data.external.thumbprint.result.thumbprint]
-  url             = data.aws_eks_cluster.target.identity.0.oidc.0.issuer
+  url             = var.identity_oidc_issuer
 }

--- a/locals.tf
+++ b/locals.tf
@@ -10,7 +10,7 @@ locals {
   )
 
   cluster_oidc_url_stripped = trimprefix(
-    data.aws_eks_cluster.target.identity.0.oidc.0.issuer,
+    var.identity_oidc_issuer,
     "https://"
   )
 

--- a/security_group.tf
+++ b/security_group.tf
@@ -4,7 +4,7 @@ resource "aws_security_group" "efs" {
 
   # vpc_config is technically a list but in practice
   # contains only one element
-  vpc_id = data.aws_eks_cluster.target.vpc_config.0.vpc_id
+  vpc_id = var.vpc_id
   tags   = local.security_group_tags
 }
 

--- a/vars.tf
+++ b/vars.tf
@@ -10,6 +10,18 @@ variable "cluster_name" {
   nullable    = false
 }
 
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID hosting target EKS and EFS resources"
+  nullable    = false
+}
+
+variable "identity_oidc_issuer" {
+  type        = string
+  description = "OIDC issuer URL for the EKS cluster"
+  nullable    = false
+}
+
 variable "cluster_node_group_subnets" {
   type        = list(string)
   description = "EKS node group subnets that will access EFS"


### PR DESCRIPTION
# Why?

Inferring cluster details via `data` resource requires there to be a cluster, which means TF codebases tightly coupled to this module fail when creating new clusters. We should just use dependency injection to the module instead of inference

# What's changing?

* Stop inferring the following cluster details via data resource and use dependency injection instead:
  * vpc id
  * cluster oidc issuer url