### PR TITLE
Update efs throughput mode to elastic

### DIFF
--- a/efs.tf
+++ b/efs.tf
@@ -1,7 +1,8 @@
 resource "aws_efs_file_system" "data" {
-  creation_token = local.efs_tags.Name
-  encrypted      = true
-  tags           = local.efs_tags
+  creation_token  = local.efs_tags.Name
+  encrypted       = true
+  tags            = local.efs_tags
+  throughput_mode = "elastic"
 }
 
 resource "aws_efs_mount_target" "data" {

--- a/efs.tf
+++ b/efs.tf
@@ -2,7 +2,7 @@ resource "aws_efs_file_system" "data" {
   creation_token  = local.efs_tags.Name
   encrypted       = true
   tags            = local.efs_tags
-  throughput_mode = "elastic"
+  throughput_mode = var.efs_throughput_mode
 }
 
 resource "aws_efs_mount_target" "data" {

--- a/vars.tf
+++ b/vars.tf
@@ -46,6 +46,12 @@ variable "efs_tags" {
   default     = {}
 }
 
+variable "efs_throughput_mode" {
+  type        = string
+  description = "throughput mode for EFS volumee"
+  default     = "burstable"
+}
+
 variable "security_group_tags" {
   type        = map(string)
   description = "resource tags for EFS security group"


### PR DESCRIPTION
The default `burstable` creates problems when we have lots of ASTs. Switching to `elastic` fixes it.