### PR TITLE
Update vars.tf

### DIFF
--- a/vars.tf
+++ b/vars.tf
@@ -49,7 +49,7 @@ variable "efs_tags" {
 variable "efs_throughput_mode" {
   type        = string
   description = "throughput mode for EFS volumee"
-  default     = "burstable"
+  default     = "bursting"
 }
 
 variable "security_group_tags" {


### PR DESCRIPTION
I made a mistake and used `burstable` when it should have been `bursting` per the [docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/efs_file_system#throughput_mode-1)